### PR TITLE
feat(ci): setup Renovate for automated dependency updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    ".renovate/labels.json5",
+    ".renovate/semanticCommits.json5"
   ],
   "schedule": [
     "before 6am on Monday"
@@ -14,85 +16,6 @@
   "prHourlyLimit": 2,
   "rangeStrategy": "pin",
   "packageRules": [
-    {
-      "description": "Label major updates",
-      "matchUpdateTypes": ["major"],
-      "labels": ["type/major"]
-    },
-    {
-      "description": "Label minor updates",
-      "matchUpdateTypes": ["minor"],
-      "labels": ["type/minor"]
-    },
-    {
-      "description": "Label patch updates",
-      "matchUpdateTypes": ["patch"],
-      "labels": ["type/patch"]
-    },
-    {
-      "description": "Label digest updates",
-      "matchUpdateTypes": ["digest"],
-      "labels": ["type/digest"]
-    },
-    {
-      "description": "Label Docker/container updates",
-      "matchDatasources": ["docker"],
-      "addLabels": ["renovate/container"]
-    },
-    {
-      "description": "Label GitHub Actions updates",
-      "matchManagers": ["github-actions"],
-      "addLabels": ["renovate/github-action"]
-    },
-    {
-      "description": "Label Python package updates",
-      "matchManagers": ["pip_requirements"],
-      "addLabels": ["renovate/python"]
-    },
-    {
-      "description": "Semantic commits for major updates",
-      "matchUpdateTypes": ["major"],
-      "semanticCommitType": "feat",
-      "commitMessagePrefix": "{{semanticCommitType}}({{semanticCommitScope}})!:",
-      "commitMessageExtra": "( {{currentVersion}} → {{newVersion}} )"
-    },
-    {
-      "description": "Semantic commits for minor updates",
-      "matchUpdateTypes": ["minor"],
-      "semanticCommitType": "feat",
-      "commitMessageExtra": "( {{currentVersion}} → {{newVersion}} )"
-    },
-    {
-      "description": "Semantic commits for patch updates",
-      "matchUpdateTypes": ["patch"],
-      "semanticCommitType": "fix",
-      "commitMessageExtra": "( {{currentVersion}} → {{newVersion}} )"
-    },
-    {
-      "description": "Semantic commits for digest updates",
-      "matchUpdateTypes": ["digest"],
-      "semanticCommitType": "chore",
-      "commitMessageExtra": "( {{currentDigestShort}} → {{newDigestShort}} )"
-    },
-    {
-      "description": "Docker semantic commits",
-      "matchDatasources": ["docker"],
-      "semanticCommitScope": "container",
-      "commitMessageTopic": "image {{depName}}"
-    },
-    {
-      "description": "GitHub Actions semantic commits",
-      "matchManagers": ["github-actions"],
-      "semanticCommitType": "ci",
-      "semanticCommitScope": "github-action",
-      "commitMessageTopic": "action {{depName}}"
-    },
-    {
-      "description": "Python package semantic commits",
-      "matchManagers": ["pip_requirements"],
-      "semanticCommitScope": "deps",
-      "commitMessageTopic": "{{depName}}"
-    },
     {
       "description": "Pin GitHub Actions to SHA",
       "matchManagers": ["github-actions"],

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,25 @@
+name: Renovate
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    # Run once per day at 2am UTC
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Run Renovate
+        uses: renovatebot/github-action@v40.3.2
+        with:
+          configurationFile: .github/renovate.json
+          token: ${{ secrets.RENOVATE_TOKEN }}
+        env:
+          LOG_LEVEL: debug

--- a/.renovate/labels.json5
+++ b/.renovate/labels.json5
@@ -1,0 +1,40 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  packageRules: [
+    {
+      description: "Label major updates",
+      matchUpdateTypes: ["major"],
+      labels: ["type/major"],
+    },
+    {
+      description: "Label minor updates",
+      matchUpdateTypes: ["minor"],
+      labels: ["type/minor"],
+    },
+    {
+      description: "Label patch updates",
+      matchUpdateTypes: ["patch"],
+      labels: ["type/patch"],
+    },
+    {
+      description: "Label digest updates",
+      matchUpdateTypes: ["digest"],
+      labels: ["type/digest"],
+    },
+    {
+      description: "Label Docker/container updates",
+      matchDatasources: ["docker"],
+      addLabels: ["renovate/container"],
+    },
+    {
+      description: "Label GitHub Actions updates",
+      matchManagers: ["github-actions"],
+      addLabels: ["renovate/github-action"],
+    },
+    {
+      description: "Label Python package updates",
+      matchManagers: ["pip_requirements"],
+      addLabels: ["renovate/python"],
+    },
+  ],
+}

--- a/.renovate/semanticCommits.json5
+++ b/.renovate/semanticCommits.json5
@@ -1,0 +1,49 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  packageRules: [
+    {
+      description: "Semantic commits for major updates",
+      matchUpdateTypes: ["major"],
+      semanticCommitType: "feat",
+      commitMessagePrefix: "{{semanticCommitType}}({{semanticCommitScope}})!:",
+      commitMessageExtra: "( {{currentVersion}} → {{newVersion}} )",
+    },
+    {
+      description: "Semantic commits for minor updates",
+      matchUpdateTypes: ["minor"],
+      semanticCommitType: "feat",
+      commitMessageExtra: "( {{currentVersion}} → {{newVersion}} )",
+    },
+    {
+      description: "Semantic commits for patch updates",
+      matchUpdateTypes: ["patch"],
+      semanticCommitType: "fix",
+      commitMessageExtra: "( {{currentVersion}} → {{newVersion}} )",
+    },
+    {
+      description: "Semantic commits for digest updates",
+      matchUpdateTypes: ["digest"],
+      semanticCommitType: "chore",
+      commitMessageExtra: "( {{currentDigestShort}} → {{newDigestShort}} )",
+    },
+    {
+      description: "Docker semantic commits",
+      matchDatasources: ["docker"],
+      semanticCommitScope: "container",
+      commitMessageTopic: "image {{depName}}",
+    },
+    {
+      description: "GitHub Actions semantic commits",
+      matchManagers: ["github-actions"],
+      semanticCommitType: "ci",
+      semanticCommitScope: "github-action",
+      commitMessageTopic: "action {{depName}}",
+    },
+    {
+      description: "Python package semantic commits",
+      matchManagers: ["pip_requirements"],
+      semanticCommitScope: "deps",
+      commitMessageTopic: "{{depName}}",
+    },
+  ],
+}


### PR DESCRIPTION
## Description
Implements automated dependency management using Renovate as outlined in #5.

## Changes

### Modular Configuration Structure
- ✅ Created `.renovate/` directory for modular configuration
- ✅ Created `.renovate/labels.json5` - Label rules for update types and datasources
- ✅ Created `.renovate/semanticCommits.json5` - Semantic commit message templates
- ✅ Updated main `renovate.json` to extend modular configs

### Labels Created
- ✅ `type/major` - Major version updates (breaking changes)
- ✅ `type/minor` - Minor version updates (new features)
- ✅ `type/patch` - Patch updates (bug fixes)
- ✅ `type/digest` - Digest/SHA updates
- ✅ `renovate/container` - Docker/container updates
- ✅ `renovate/github-action` - GitHub Actions updates
- ✅ `renovate/python` - Python package updates

### GitHub Actions Workflow
- ✅ Created `.github/workflows/renovate.yml`
- Triggers:
  - Push to main branch
  - Daily schedule at 2am UTC
  - Manual workflow_dispatch

### Configuration Features
- Managers: pip_requirements, dockerfile, github-actions
- Auto-labeling by update type and datasource
- Semantic commit messages
- Grouping: pytest packages, black/ruff tools
- Auto-merge for patch and digest updates after CI passes
- Schedule: Weekly on Monday mornings
- Security: SHA pinning for GitHub Actions
- Approval required for major version updates

## Next Steps
To activate Renovate:
1. Add `RENOVATE_TOKEN` secret to repository (GitHub PAT with repo permissions)
2. Merge this PR
3. Renovate will run on next push to main or daily schedule
4. Initial PRs will be created for available updates

## Example Commit Messages
- `feat(deps)!: requests ( 2.31.0 → 3.0.0 )` - Major update
- `feat(deps): pytest ( 7.4.3 → 7.5.0 )` - Minor update
- `fix(deps): black ( 24.1.1 → 24.1.2 )` - Patch update
- `ci(github-action): action actions/checkout ( v4 → v5 )` - GitHub Actions
- `chore(container): image python ( abc123 → def456 )` - Docker digest

Closes #5
