### PR TITLE
feat(helm): add OCI artifact support for Helm chart distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,3 +118,34 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  helm-publish:
+    needs: release
+    if: needs.release.outputs.new_release_version != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        with:
+          ref: v${{ needs.release.outputs.new_release_version }}
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: 'latest'
+
+      - name: Package Helm chart
+        run: |
+          helm package ./helm/syncbit --version ${{ needs.release.outputs.new_release_version }}
+
+      - name: Log in to GitHub Container Registry
+        run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Push Helm chart to OCI registry
+        run: |
+          helm push syncbit-${{ needs.release.outputs.new_release_version }}.tgz oci://ghcr.io/${{ github.repository_owner }}/charts


### PR DESCRIPTION
## Summary

Adds support for publishing the Helm chart as an OCI artifact to GitHub Container Registry. Users can now install the chart directly from `oci://ghcr.io/origox/charts/syncbit`.

## Changes

- ✅ Added `helm-publish` job to release workflow
- ✅ Packages Helm chart with semantic version
- ✅ Pushes chart to `ghcr.io/origox/charts`
- ✅ Updated README with OCI installation instructions
- ✅ Added ArgoCD Application example using OCI registry
- ✅ Marked OCI registry as recommended installation method

## Benefits

- **Single registry**: Both Docker images and Helm charts in GHCR
- **Better versioning**: Chart version matches semantic release version
- **Simpler GitOps**: ArgoCD/Flux can use OCI repositories directly
- **No infrastructure**: No need for separate Helm repository server

## Installation Examples

### Helm CLI
\`\`\`bash
helm install syncbit oci://ghcr.io/origox/charts/syncbit --version 1.4.0
\`\`\`

### ArgoCD
\`\`\`yaml
source:
  chart: syncbit
  repoURL: ghcr.io/origox/charts
  targetRevision: 1.4.0
\`\`\`

## Testing

After merge and release, the chart will be available at:
- Registry: `ghcr.io/origox/charts`
- Chart: `syncbit`
- Versions: Match GitHub releases (e.g., `1.5.0`)

## Related

Closes #29

